### PR TITLE
use cross-browser compatible check to determine if node is an SVG

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export default function(nodeOrSelector: Element | string): Styler {
     ? document.querySelector(nodeOrSelector)
     : nodeOrSelector;
 
-  return (node instanceof SVGGraphicsElement) ? svg(node) : css(node as HTMLElement);
+  return (node instanceof SVGElement) ? svg(node) : css(node as HTMLElement);
 }
 
 export { createStyler, Styler };

--- a/src/svg/index.ts
+++ b/src/svg/index.ts
@@ -12,7 +12,7 @@ type SVGProps = {
     width: number,
     height: number
   },
-  element: SVGGraphicsElement,
+  element: SVGElement,
   isPath: boolean,
   pathLength?: number
 };
@@ -36,7 +36,7 @@ const svgStyler = createStyler({
   }
 });
 
-export default (element: SVGGraphicsElement | SVGPathElement): Styler => {
+export default (element: SVGElement | SVGPathElement): Styler => {
   const { x, y, width, height } = element.getBBox();
   const props: SVGProps = {
     element,


### PR DESCRIPTION
Pertaining to https://github.com/Popmotion/stylefire/issues/2, `SVGElement` seems to be a cross-browser compatible check to determine if a node is an SVG or not. It seemed that this was the only use case for `SVGGraphicsElement`, so hopefully it's a safe swap.

I tested [this small Codepen](https://codepen.io/souporserious/pen/b7151ae124cb420a07a10f42e82ea87b) in major browsers as well as IE11 and it seems to be working.
![image](https://user-images.githubusercontent.com/2762082/34082350-448b5e94-e311-11e7-8777-3d7dff16f9a7.png)
