### PR TITLE
fix: prevent extra render when using `render` method

### DIFF
--- a/src/styler/index.ts
+++ b/src/styler/index.ts
@@ -22,11 +22,15 @@ const createStyler = ({ onRead, onRender, aliasMap = {}, useCache = true }: Conf
     }
   };
 
-  const render = () => {
-    onRender(state, props, changedValues);
-    hasChanged = false;
-    changedValues.length = 0;
-  };
+  function render(forceRender = false) {
+    if (forceRender || hasChanged) {
+      onRender(state, props, changedValues);
+      hasChanged = false;
+      changedValues.length = 0;
+    }
+
+    return this;
+  }
 
   return {
     get(unmappedKey: string) {
@@ -55,11 +59,7 @@ const createStyler = ({ onRead, onRender, aliasMap = {}, useCache = true }: Conf
 
       return this;
     },
-    render(forceRender = false) {
-      if (forceRender || hasChanged) render();
-
-      return this;
-    },
+    render,
   };
 };
 


### PR DESCRIPTION
Example:
  `css(node).set('y', 10).render()`

The call to `set` will queue the update for the next frame.
But the call to `render` will handle the changes immediately.
Currently, the queued update still fires, which is fine, but
we should check `hasChanges` to avoid the superfluous call
to the `onRender` callback, which is pointless since the
`changedValues` array is always empty by that time.

To accomplish this, I'm hoisting the `render` method so it
can be passed to framesync, which means the `render` helper
function can be merged into the `render` method.